### PR TITLE
Adds ability to optionally ignore deleting a specific Tweet

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The following environment variables exist for configuration:
 |`CONSUMERKEY`|Twitter API credential|Y||
 |`CONSUMERSECRET`|Twitter API credential|Y||
 |`DAYSTOKEEP`|The number of days to keep Tweets before they're deleted|N|`30`|
+|`IGNOREID`|The Tweet ID of a Tweet you'd like to be ignored (e.g. a pinned Tweet)|N||
 |`TWEETCOUNT`|This is an API detail - the number of Tweets that'll be retrieved, `3200` is the max|N|`3200`|
 |`INCLUDERETWEETS`|Whether RT's should be included in the search/deletion|N|`true`|
 |`SCREENNAME`|Your Twitter handle|Y||

--- a/config/main.go
+++ b/config/main.go
@@ -11,6 +11,7 @@ type Config struct {
 	ConsumerKey     string `required:"true"`
 	ConsumerSecret  string `required:"true"`
 	DaysToKeep      int    `default:"30"`
+	IgnoreID        int64
 	TweetCount      int    `default:"3200"`
 	IncludeRetweets bool   `default:"true"`
 	ScreenName      string `required:"true"`

--- a/main.go
+++ b/main.go
@@ -1,8 +1,9 @@
 package main
 
 import (
-	"github.com/jadametz/goTweetDelete/twitter"
 	"os"
+
+	"github.com/jadametz/goTweetDelete/twitter"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -18,12 +19,13 @@ func main() {
 		log.WithError(err).Fatal("Unable to create Twitter struct")
 	}
 
-	deleted, skipped, err := t.DeleteOldTweets()
+	deleted, ignored, skipped, err := t.DeleteOldTweets()
 	if err != nil {
 		log.WithError(err).Error("Issue deleting Tweets")
 	}
 	log.WithFields(log.Fields{
 		"deleted": deleted,
+		"ignored": ignored,
 		"skipped": skipped,
 	}).Info("Tweet evaluation complete")
 


### PR DESCRIPTION
This allows the user to "ignore" deleting a specific Tweet. This is particularly useful for example with pinned Tweets, which the Twitter API doesn't allow for the programmatic identification of.

Resolves #2 