### PR TITLE
Ensure all tweets are retrieved.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ The following environment variables exist for configuration:
 |`CONSUMERSECRET`|Twitter API credential|Y||
 |`DAYSTOKEEP`|The number of days to keep Tweets before they're deleted|N|`30`|
 |`IGNOREID`|The Tweet ID of a Tweet you'd like to be ignored (e.g. a pinned Tweet)|N||
-|`TWEETCOUNT`|This is an API detail - the number of Tweets that'll be retrieved, `3200` is the max|N|`3200`|
 |`INCLUDERETWEETS`|Whether RT's should be included in the search/deletion|N|`true`|
 |`SCREENNAME`|Your Twitter handle|Y||
 

--- a/config/main.go
+++ b/config/main.go
@@ -12,7 +12,6 @@ type Config struct {
 	ConsumerSecret  string `required:"true"`
 	DaysToKeep      int    `default:"30"`
 	IgnoreID        int64
-	TweetCount      int    `default:"3200"`
 	IncludeRetweets bool   `default:"true"`
 	ScreenName      string `required:"true"`
 }


### PR DESCRIPTION
Previously the TweetCount parameter was being passed, but ignored, to
the Twitter API. The API will only ever return <= 200 tweets. This
ensures that all Tweets in the users timeline are pulled and considered.

This should resolve #4.