### PR TITLE
Add support for multiple IDs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ The following environment variables exist for configuration:
 |`CONSUMERKEY`|Twitter API credential|Y||
 |`CONSUMERSECRET`|Twitter API credential|Y||
 |`DAYSTOKEEP`|The number of days to keep Tweets before they're deleted|N|`30`|
-|`IGNOREID`|The Tweet ID of a Tweet you'd like to be ignored (e.g. a pinned Tweet)|N||
+|`IGNOREID`|The Tweet ID(s), comma separated, of a Tweet you'd like to be ignored (e.g. a pinned Tweet)|N||
+|`IGNOREIDS`|The Tweet ID(s), comma separated, of a Tweet you'd like to be ignored (e.g. a pinned Tweet)|N||
 |`INCLUDERETWEETS`|Whether RT's should be included in the search/deletion|N|`true`|
 |`SCREENNAME`|Your Twitter handle|Y||
 

--- a/config/main.go
+++ b/config/main.go
@@ -11,9 +11,24 @@ type Config struct {
 	ConsumerKey     string `required:"true"`
 	ConsumerSecret  string `required:"true"`
 	DaysToKeep      int    `default:"30"`
-	IgnoreID        int64
+	IgnoreID        []int64
+	IgnoreIDs       []int64
 	IncludeRetweets bool   `default:"true"`
 	ScreenName      string `required:"true"`
+}
+
+func (c *Config) ShouldIgnoreId(id int64) bool {
+	for _, i := range c.IgnoreID {
+		if i == id {
+			return true
+		}
+	}
+	for _, i := range c.IgnoreIDs {
+		if i == id {
+			return true
+		}
+	}
+	return false
 }
 
 // New returns a new Config struct

--- a/config/main_test.go
+++ b/config/main_test.go
@@ -1,0 +1,91 @@
+package config
+
+import "testing"
+
+func TestConfig_ShouldIgnoreId(t *testing.T) {
+	type fields struct {
+		IgnoreID  []int64
+		IgnoreIDs []int64
+	}
+	type args struct {
+		id int64
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   bool
+	}{
+		{
+			name:   "One ID provided and found",
+			fields: fields{IgnoreID: []int64{123}},
+			args:   args{id: int64(123)},
+			want:   true,
+		},
+		{
+			name:   "One ID provided but not found",
+			fields: fields{IgnoreID: []int64{123}},
+			args:   args{id: int64(321)},
+			want:   false,
+		},
+		{
+			name:   "Multiple IDs provided but not found",
+			fields: fields{IgnoreID: []int64{123, 456}},
+			args:   args{id: int64(321)},
+			want:   false,
+		},
+		{
+			name:   "Multiple IDs provided and one found",
+			fields: fields{IgnoreID: []int64{123, 456}},
+			args:   args{id: int64(456)},
+			want:   true,
+		},
+		{
+			name:   "No IDs provided",
+			fields: fields{IgnoreID: nil},
+			args:   args{id: int64(456)},
+			want:   false,
+		},
+		{
+			name:   "One ID provided and found (plural)",
+			fields: fields{IgnoreID: []int64{123}},
+			args:   args{id: int64(123)},
+			want:   true,
+		},
+		{
+			name:   "One ID provided but not found (plural)",
+			fields: fields{IgnoreID: []int64{123}},
+			args:   args{id: int64(321)},
+			want:   false,
+		},
+		{
+			name:   "Multiple IDs provided but not found (plural)",
+			fields: fields{IgnoreID: []int64{123, 456}},
+			args:   args{id: int64(321)},
+			want:   false,
+		},
+		{
+			name:   "Multiple IDs provided and one found (plural)",
+			fields: fields{IgnoreID: []int64{123, 456}},
+			args:   args{id: int64(456)},
+			want:   true,
+		},
+		{
+			name:   "No IDs provided (plural)",
+			fields: fields{IgnoreIDs: nil},
+			args:   args{id: int64(456)},
+			want:   false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Config{
+				IgnoreID:  tt.fields.IgnoreID,
+				IgnoreIDs: tt.fields.IgnoreIDs,
+			}
+			if got := c.ShouldIgnoreId(tt.args.id); got != tt.want {
+				t.Errorf("Config.ShouldIgnoreId() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/twitter/main.go
+++ b/twitter/main.go
@@ -58,7 +58,7 @@ func (t *Twitter) DeleteOldTweets() (deleted, ignored, skipped int, err error) {
 	}
 
 	for _, tweet := range allTweets {
-		if tweet.ID == t.Config.IgnoreID {
+		if t.Config.ShouldIgnoreId(tweet.ID) {
 			ignored++
 			continue
 		}


### PR DESCRIPTION
I decided to go with option 4. The added complexity is trivial, and it doesn't present the risk of a breaking change accidentally deleting a tweet.

This resolves #8.